### PR TITLE
Ensure child element references are removed from parents on detach

### DIFF
--- a/test/px-map-marker-fixture.html
+++ b/test/px-map-marker-fixture.html
@@ -84,6 +84,14 @@
       </template>
     </test-fixture>
 
+    <test-fixture id="ImperativeAddRemoveFixture">
+      <template>
+        <px-map style="height: 400px; width: 400px;">
+          <px-map-marker-static lat="37" lng="122" type="custom-0"></px-map-marker-static>
+        </px-map>
+      </template>
+    </test-fixture>
+
     <!-- load test script -->
     <script src="px-map-marker-tests.js"></script>
   </body>

--- a/test/px-map-marker-tests.js
+++ b/test/px-map-marker-tests.js
@@ -222,3 +222,36 @@ describe('px-map-marker-symbol with custom type', function() {
       </div>`).replace(/\s+/g, ''));
   });
 });
+
+
+describe('px-map-marker-* lifecycle', function() {
+  var map;
+  var marker;
+
+  beforeEach(function(done) {
+    map = fixture('ImperativeAddRemoveFixture');
+
+    Polymer.RenderStatus.afterNextRender(map, () => {
+      flush(() => {
+        marker = map.querySelector('px-map-marker-static');
+        done();
+      });
+    });
+  });
+
+  it('re-attaches a marker marker that is imperatively removed and re-added to the DOM', function(done) {
+    expect(map._attachedChildren.has(marker)).to.be.true;
+    map.removeChild(marker);
+
+    flush(() => {
+      expect(map._attachedChildren.has(marker)).to.be.false;
+      expect(marker.elementInst._map).to.not.exist;
+      map.appendChild(marker);
+      flush(() => {
+        expect(map._attachedChildren.has(marker)).to.be.true;
+        expect(marker.elementInst._map).to.exist;
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes a bug where markers (or other layers) that are imperatively detached from the DOM and then re-attached aren't re-attached to the map.