### PR TITLE
Fix popup width regression

### DIFF
--- a/demo/px-map-popup-data-demo.html
+++ b/demo/px-map-popup-data-demo.html
@@ -70,7 +70,8 @@ limitations under the License.
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-marker-static lat="37.7673626" lng="-121.9595048" type="info">
             <px-map-popup-data
-              min-width="350"
+              min-width="{{props.minWidth.value}}"
+              max-width="{{props.maxWidth.value}}"
               title="{{props.title.value}}"
               data="{{props.data.value}}">
             </px-map-popup-data>
@@ -179,6 +180,20 @@ limitations under the License.
           type: Object,
           defaultValue: { "Employees" : "2000", "Parking" : "Yes", "Snacks" : "Yes", "Gym" : "No" },
           inputType: 'code:JSON'
+        },
+
+        minWidth: {
+          inputLabel: 'Minimum width (in px)',
+          type: Number,
+          defaultValue: 350,
+          inputType: 'number'
+        },
+
+        maxWidth: {
+          inputLabel: 'Maximum width (in px)',
+          type: Number,
+          defaultValue: 500,
+          inputType: 'number'
         },
 
         parentComponent: {

--- a/demo/px-map-popup-info-demo.html
+++ b/demo/px-map-popup-info-demo.html
@@ -65,7 +65,7 @@ limitations under the License.
           attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap contributors</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-marker-static lat="42.3518414" lng="-71.0500149" type="info">
-            <px-map-popup-info min-width="200" title="{{props.title.value}}" description="{{props.description.value}}"></px-map-popup-info>
+            <px-map-popup-info min-width="{{props.minWidth.value}}" max-width="{{props.maxWidth.value}}" title="{{props.title.value}}" description="{{props.description.value}}"></px-map-popup-info>
           </px-map-marker-static>
         </px-map>
       </div>
@@ -171,6 +171,20 @@ limitations under the License.
           type: String,
           defaultValue: 'The new GE Corporate headquarters in Boston will be known as GE Innovation Point.',
           inputType: 'text'
+        },
+
+        minWidth: {
+          inputLabel: 'Minimum width (in px)',
+          type: Number,
+          defaultValue: 350,
+          inputType: 'number'
+        },
+
+        maxWidth: {
+          inputLabel: 'Maximum width (in px)',
+          type: Number,
+          defaultValue: 400,
+          inputType: 'number'
         },
 
         parentComponent: {

--- a/px-map-behavior-marker-group.es6.js
+++ b/px-map-behavior-marker-group.es6.js
@@ -851,7 +851,12 @@
     _bindAndOpenPopup(marker) {
       if (!marker || !marker.bindPopup || !marker.openPopup) return;
 
-      const popupSettings = this._featSettingsToProps(marker.featureProperties['marker-popup'], 'popup');
+      const defaults = {
+        minWidth: PxMapBehavior.PopupImpl.properties.minWidth.value,
+        maxWidth: PxMapBehavior.PopupImpl.properties.maxWidth.value
+      }
+
+      const popupSettings = Object.assign(defaults, this._featSettingsToProps(marker.featureProperties['marker-popup'], 'popup'));
       if (!popupSettings || !Object.keys(popupSettings).length) return;
 
       const klassName = (popupSettings._Base && PxMap.hasOwnProperty(popupSettings._Base)) ? popupSettings._Base : 'InfoPopup';

--- a/px-map-behavior-popup.es6.js
+++ b/px-map-behavior-popup.es6.js
@@ -47,6 +47,7 @@
       maxWidth: {
         type: Number,
         value: 400,
+        observer: 'shouldUpdateInst'
       },
 
       /**
@@ -55,6 +56,7 @@
       minWidth: {
         type: Number,
         value: 300,
+        observer: 'shouldUpdateInst'
       },
 
       /**
@@ -109,6 +111,12 @@
         } else if (!nextOptions.opened && this.elementInst.isOpen()) {
           this.elementInst._source.closePopup();
         }
+      }
+      if (nextOptions.minWidth !== lastOptions.minWidth || nextOptions.maxWidth !== lastOptions.maxWidth) {
+        const minWidth = nextOptions.minWidth || lastOptions.minWidth;
+        const maxWidth = nextOptions.maxWidth || lastOptions.maxWidth;
+        
+        this.elementInst.updateSettings({minWidth, maxWidth})
       }
     },
 
@@ -421,7 +429,8 @@
 
     updateSettings(settings={}) {
       Object.assign(this.settings, settings);
-      const { title, description, imgSrc, styleScope } = this.settings;
+      const { title, description, imgSrc, minWidth, maxWidth } = this.settings;
+      Object.assign(this.options, { minWidth, maxWidth });
       const content = this._generatePopupContent(title, description, imgSrc);
 
       this.setContent(content);
@@ -547,7 +556,8 @@
 
     updateSettings(settings={}) {
       Object.assign(this.settings, settings);
-      const { title, data } = this.settings;
+      const { title, data, minWidth, maxWidth } = this.settings;
+      Object.assign(this.options, { minWidth, maxWidth });
       const content = this._generatePopupContent(title, data);
 
       if (this.isOpen() && Object.keys(data).length === 0) {


### PR DESCRIPTION
* ## Description:
Addresses a regression from the previous release - popups defined within a marker-group's configuration did not inherit the min/max width values from the base popup implementation and appeared too narrow.

**Before:**
![image](https://user-images.githubusercontent.com/4055224/50462888-4e24cb00-09dc-11e9-9995-0e5a1e8dd3cb.png)

**Now:**
<img width="330" alt="screen shot 2018-12-27 at 1 36 07 pm" src="https://user-images.githubusercontent.com/4055224/50462907-63015e80-09dc-11e9-8dc6-b8116a7cc529.png">

I've also fixed the `minWidth` and `maxWidth` properties not updating the popup if modified after the popup has initialised, and added the min/max width props to the demos.

* ## A reference to a related issue (if applicable):

Fixes #138 