### PR TITLE
Fixed marker zoom calculation when fitting map viewport to marker bounds

### DIFF
--- a/px-map-behavior-root.es6.js
+++ b/px-map-behavior-root.es6.js
@@ -233,12 +233,10 @@
      */
     _getZoomLevelForFit(bounds, fitSetting, map) {
       if (fitSetting === 'min') {
-        let zoom = map.getMinZoom() || 0;
-        return zoom;
+        return map.getMinZoom() || 0;
       }
       if (fitSetting === 'max') {
-        let zoom = map.getBoundsZoom(bounds, true) - 1;
-        return zoom;
+        return map.getBoundsZoom(bounds);
       }
     },
 

--- a/test/px-map-root-tests.js
+++ b/test/px-map-root-tests.js
@@ -386,7 +386,7 @@ describe('px-map with fit-to-markers enabled', function() {
       var spy = sinon.spy(mapEl, '_getZoomLevelForFit');
       var fakeMap = {
         getMinZoom: sinon.stub().returns(5),
-        getBoundsZoom: sinon.stub().returns(12)
+        getBoundsZoom: sinon.stub().returns(11)
       };
       var fakeBounds = sinon.stub();
 
@@ -394,7 +394,7 @@ describe('px-map with fit-to-markers enabled', function() {
       expect(callWithMin).to.eql(5); // should equal map.getMinZoom()
 
       var callWithMax = mapEl._getZoomLevelForFit(fakeBounds, 'max', fakeMap);
-      expect(callWithMax).to.eql(11); // should equal map.getBoundsZoom() - 1
+      expect(callWithMax).to.eql(11); // should equal map.getBoundsZoom()
     });
 
     it('corretly sets its view', function() {


### PR DESCRIPTION
# Pull Request

* ## A description of the changes proposed in the pull request:

When fitting the map viewport to bounds (via the `fit-to-markers` prop), the zoom level is incorrectly calculated when there's > 1 marker to fit to.

The current implementation uses leaflet's [getBoundsZoom](https://leafletjs.com/reference-1.0.0.html#map-getboundszoom)'s method to calculate the zoom level _inside_ the marker bounds, then subtracts 1 to get the outer bounds. The logic makes sense but the implementation doesn't work.

Simply omitting the `inside` flag seems to correctly calculate the zoom level in all scenarios I'm aware of.

With the following example code:
```html
<px-map flex-to-size fit-to-markers> 
  <px-map-marker-static lat="37.6654861" lng="-122.7706668" type="unknown"></px-map-marker-static>
  <px-map-marker-static lat="40.213000" lng="-121.564100" type="warning"></px-map-marker-static>
  <px-map-tile-layer url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'></px-map-tile-layer>
  <px-map-control-zoom position="bottomright"></px-map-control-zoom>
</px-map>
```

**Before: (zoom level too high, no visible markers)**
<img width="614" alt="screen shot 2018-12-28 at 10 25 58 am" src="https://user-images.githubusercontent.com/4055224/50497378-fe510d00-0a8a-11e9-8f0d-b5d7ca92607b.png">


**After:**
<img width="609" alt="screen shot 2018-12-28 at 10 25 17 am" src="https://user-images.githubusercontent.com/4055224/50497364-ec6f6a00-0a8a-11e9-948a-54524999871c.png">


* ## A reference to a related issue (if applicable):
Resolves #132 
