### PR TITLE
Default popup min/max widths are now applied in the _createPopup override

### DIFF
--- a/px-map-behavior-marker-group.es6.js
+++ b/px-map-behavior-marker-group.es6.js
@@ -851,12 +851,7 @@
     _bindAndOpenPopup(marker) {
       if (!marker || !marker.bindPopup || !marker.openPopup) return;
 
-      const defaults = {
-        minWidth: PxMapBehavior.PopupImpl.properties.minWidth.value,
-        maxWidth: PxMapBehavior.PopupImpl.properties.maxWidth.value
-      }
-
-      const popupSettings = Object.assign(defaults, this._featSettingsToProps(marker.featureProperties['marker-popup'], 'popup'));
+      const popupSettings = this._featSettingsToProps(marker.featureProperties['marker-popup'], 'popup');
       if (!popupSettings || !Object.keys(popupSettings).length) return;
 
       const klassName = (popupSettings._Base && PxMap.hasOwnProperty(popupSettings._Base)) ? popupSettings._Base : 'InfoPopup';

--- a/px-map-behavior-popup.es6.js
+++ b/px-map-behavior-popup.es6.js
@@ -389,10 +389,14 @@
 
     // Note `createPopup` is an internet explorer native method, but deprecated
     // so hopefully it won't cause grief
-    _createPopup(settings={}) {
+    _createPopup({title = null,
+                  description = null,
+                  imgSrc = null,
+                  styleScope = null,
+                  minWidth = PxMapBehavior.PopupImpl.properties.minWidth.value,
+                  maxWidth = PxMapBehavior.PopupImpl.properties.maxWidth.value}={}) {
       // Assign settings and create content
-      this.settings = settings;
-      const { title, description, imgSrc, styleScope, maxWidth, minWidth } = settings;
+      this.settings = { title, description, imgSrc, styleScope, minWidth, maxWidth };
       const content = this._generatePopupContent(title, description, imgSrc);
       const className = `map-popup-info ${styleScope||''}`
 
@@ -402,7 +406,7 @@
 
     _generatePopupContent(title, description, imgSrc) {
       let tmplFnIf = (fn, ...vals) =>
-        vals.length && vals[0] !== undefined ? fn.call(this, ...vals) : '';
+        vals.length && vals[0] != null ? fn.call(this, ...vals) : '';
 
       let imgTmpl = (imgSrc) => `
         <div class="map-box-info__image">
@@ -510,9 +514,13 @@
 
     // Note `createPopup` is an internet explorer native method, but deprecated
     // so hopefully it won't cause grief
-    _createPopup(settings={}, config={}) {
-      this.settings = settings;
-      const { title, data, styleScope, maxWidth, minWidth } = settings;
+    _createPopup({title = null,
+                  data = null,
+                  styleScope = null,
+                  minWidth = PxMapBehavior.PopupImpl.properties.minWidth.value,
+                  maxWidth = PxMapBehavior.PopupImpl.properties.maxWidth.value}={}) {
+      // Merge defaults into settings param
+      this.settings = { title, data, styleScope, minWidth, maxWidth };
       const content = this._generatePopupContent(title, data);
 
       const className = `map-popup-data ${styleScope||''}`
@@ -523,7 +531,7 @@
 
     _generatePopupContent(title, data) {
       let tmplFnIf = (fn, ...vals) =>
-        vals.length && vals[0] !== undefined ? fn.call(this, ...vals) : '';
+        vals.length && vals[0] != null ? fn.call(this, ...vals) : '';
 
       let titleTmpl = (title) => `
         <div class="map-data-box__header">

--- a/test/px-map-popup-tests.js
+++ b/test/px-map-popup-tests.js
@@ -116,6 +116,27 @@ describe('PxMap.InfoPopup class', function () {
 
     expect(content).to.include(NEW_TITLE_TEXT);
   });
+
+  it('inherits the default minimum and maximum width when created without these parameters', function() {
+    var popup = new PxMap.InfoPopup({});
+
+    var defaultMin = PxMapBehavior.PopupImpl.properties.minWidth.value;
+    var defaultMax = PxMapBehavior.PopupImpl.properties.maxWidth.value;
+
+    // Test leaflet props
+    expect(popup.options.minWidth).to.equal(defaultMin);
+    expect(popup.options.maxWidth).to.equal(defaultMax);
+  });
+
+  it('applies the minimum and maximum width values when specified', function() {
+    var minWidth = 123;
+    var maxWidth = 456;
+    var popup = new PxMap.InfoPopup({ minWidth: minWidth, maxWidth: maxWidth });
+
+    // Test leaflet props
+    expect(popup.options.minWidth).to.equal(minWidth);
+    expect(popup.options.maxWidth).to.equal(maxWidth);
+  });
 });
 
 /*
@@ -191,6 +212,27 @@ describe('PxMap.DataPopup class', function () {
     expect(content).to.include('Other Thing');
     expect(content).to.include('New Value');
     expect(content).to.include('999');
+  });
+
+  it('inherits the default minimum and maximum width when created without these parameters', function() {
+    var popup = new PxMap.DataPopup({});
+
+    var defaultMin = PxMapBehavior.PopupImpl.properties.minWidth.value;
+    var defaultMax = PxMapBehavior.PopupImpl.properties.maxWidth.value;
+
+    // Test leaflet props
+    expect(popup.options.minWidth).to.equal(defaultMin);
+    expect(popup.options.maxWidth).to.equal(defaultMax);
+  });
+
+  it('applies the minimum and maximum width values when specified', function() {
+    var minWidth = 321;
+    var maxWidth = 654;
+    var popup = new PxMap.DataPopup({ minWidth: minWidth, maxWidth: maxWidth });
+
+    // Test leaflet props
+    expect(popup.options.minWidth).to.equal(minWidth);
+    expect(popup.options.maxWidth).to.equal(maxWidth);
   });
 });
 


### PR DESCRIPTION
# Pull Request

* ## A description of the changes proposed in the pull request:

I noticed that the geoJSON popup also had the wrong width, so I've modified the InfoPopup and DataPopup overrides to apply the min/max width values there instead.

I also added a couple tests to make sure min/max width values are being applied correctly, whether those values are specified or not.

**Before:**
<img width="278" alt="screen shot 2018-12-28 at 3 19 29 pm" src="https://user-images.githubusercontent.com/4055224/50502526-11c49e00-0ab4-11e9-82aa-97909e7d3e38.png">

**After:**
<img width="357" alt="screen shot 2018-12-28 at 3 19 57 pm" src="https://user-images.githubusercontent.com/4055224/50502532-18531580-0ab4-11e9-9dc7-381e6c46f918.png">