### PR TITLE
px-map now prevents zooming outside the supported bounds of any children layers

### DIFF
--- a/px-map-behavior-root.es6.js
+++ b/px-map-behavior-root.es6.js
@@ -652,7 +652,6 @@
           });
         }
 
-
         this.elementInst.options.unclampZoomToLayers = nextOptions.unclampZoomToLayers;
       }
 

--- a/px-map-behavior-root.es6.js
+++ b/px-map-behavior-root.es6.js
@@ -533,14 +533,16 @@
         this.scopeSubtree(this.$.map, true);
       }
 
-      // Bind custom events for the map intance. Events will be unbound automatically.
+      // Bind custom events for the map instance. Events will be unbound automatically.
       const mapMoveFn = this._handleMapMove.bind(this);
       const zoomStartFn = this._handleZoomStart.bind(this);
       const zoomEndFn = this._handleZoomEnd.bind(this);
+      const addLayerFn = this._clampZoomForLayer;
       this.bindEvents({
         'moveend' : mapMoveFn,
         'zoomstart' : zoomStartFn,
-        'zoomend' : zoomEndFn
+        'zoomend' : zoomEndFn,
+        'layeradd' : addLayerFn
       });
     },
 
@@ -634,6 +636,20 @@
       if (!this.elementInst) return;
 
       this.elementInst.invalidateSize();
+    },
+
+    /**
+     * Overrides the configured min/max zoom levels if they fall outside
+     * the supported bounds for a layer.
+     */
+    _clampZoomForLayer(evt) {
+      if (!evt.layer || !evt.layer.options) return;
+
+      if (evt.layer.options.minZoom > this.options.minZoom) 
+        this.options.minZoom = evt.layer.options.minZoom;
+
+      if (evt.layer.options.maxZoom < this.options.maxZoom) 
+        this.options.maxZoom = evt.layer.options.maxZoom;
     },
 
     /**

--- a/px-map-behavior-root.es6.js
+++ b/px-map-behavior-root.es6.js
@@ -19,6 +19,13 @@
   'use strict';
 
   /****************************************************************************
+   * CONSTANTS
+   ****************************************************************************/
+
+  const MIN_SUPPORTED_ZOOM_LEVEL = 0;
+  const MAX_SUPPORTED_ZOOM_LEVEL = 18;
+
+  /****************************************************************************
    * BEHAVIORS
    ****************************************************************************/
 
@@ -233,7 +240,7 @@
      */
     _getZoomLevelForFit(bounds, fitSetting, map) {
       if (fitSetting === 'min') {
-        let zoom = map.getMinZoom() || 0;
+        let zoom = map.getMinZoom() || MIN_SUPPORTED_ZOOM_LEVEL;
         return zoom;
       }
       if (fitSetting === 'max') {
@@ -356,6 +363,38 @@
       minZoom: {
         type: Number,
         observer: 'shouldUpdateInst'
+      },
+
+      /**
+       * If set, respects the configured minimum and maximum zoom levels even if they fall outside
+       * the supported bounds of any children layers.
+       *
+       * @type {Boolean}
+       */
+      unclampZoomToLayers: {
+        type: Boolean,
+        value: false,
+        observer: 'shouldUpdateInst'
+      },
+
+      /**
+       * Tracks the highest minimum zoom level supported by all children layers.
+       *
+       * @type {Number}
+       */
+      _clampedMinZoom: {
+        type: Number,
+        value: MIN_SUPPORTED_ZOOM_LEVEL
+      },
+
+      /**
+       * Tracks the lowest maximum zoom level supported by all children layers.
+       *
+       * @type {Number}
+       */
+      _clampedMaxZoom: {
+        type: Number,
+        value: MAX_SUPPORTED_ZOOM_LEVEL
       },
 
       /**
@@ -537,7 +576,10 @@
       const mapMoveFn = this._handleMapMove.bind(this);
       const zoomStartFn = this._handleZoomStart.bind(this);
       const zoomEndFn = this._handleZoomEnd.bind(this);
-      const addLayerFn = this._clampZoomForLayer;
+      const addLayerFn = (evt) => {
+        if (evt.layer && evt.layer.options) 
+          this._clampZoomForLayer(evt.layer.options.minZoom, evt.layer.options.maxZoom);
+      }
       this.bindEvents({
         'moveend' : mapMoveFn,
         'zoomstart' : zoomStartFn,
@@ -563,8 +605,8 @@
       options.crs = this.crs || L.CRS.EPSG3857;
       options.center = [this.lat, this.lng];
       options.zoom = this.zoom;
-      options.minZoom = this.minZoom || 0;
-      options.maxZoom = this.maxZoom || 18;
+      options.minZoom = this.minZoom || MIN_SUPPORTED_ZOOM_LEVEL;
+      options.maxZoom = this.maxZoom || MAX_SUPPORTED_ZOOM_LEVEL;
       options.maxBounds = this.maxBounds || undefined;
 
       options.dragging = !this.disableDragging;
@@ -573,6 +615,7 @@
       options.doubleClickZoom = !this.disableDoubleClickZoom;
       options.attributionControl = !this.disableAttribution;
       options.attributionPrefix = this.attributionPrefix;
+      options.unclampZoomToLayers = this.unclampZoomToLayers;
 
       return options;
     },
@@ -586,13 +629,31 @@
       }
 
       if (lastOptions.maxZoom !== nextOptions.maxZoom && !isNaN(nextOptions.maxZoom)) {
-        this.setMaxZoom(nextOptions.maxZoom);
+        this.elementInst.setMaxZoom(Math.min(nextOptions.maxZoom, this._clampedMaxZoom));
       }
       if (lastOptions.minZoom !== nextOptions.minZoom && !isNaN(nextOptions.minZoom)) {
-        this.setMinZoom(nextOptions.minZoom);
+        this.elementInst.setMinZoom(Math.max(nextOptions.minZoom, this._clampedMinZoom));
       }
       if (lastOptions.maxBounds !== nextOptions.maxBounds && !isNaN(nextOptions.maxBounds)) {
-        this.setMaxBounds(nextOptions.maxBounds);
+        this.elementInst.setMaxBounds(nextOptions.maxBounds);
+      }
+      if (lastOptions.unclampZoomToLayers !== nextOptions.unclampZoomToLayers) {
+        if (nextOptions.unclampZoomToLayers) {
+          // Reset clamped values
+          this._clampedMinZoom = MIN_SUPPORTED_ZOOM_LEVEL;
+          this._clampedMaxZoom = MAX_SUPPORTED_ZOOM_LEVEL;
+          // Revert min/max zoom level to user specified values
+          this.elementInst.setMinZoom(nextOptions.minZoom || MIN_SUPPORTED_ZOOM_LEVEL);
+          this.elementInst.setMaxZoom(nextOptions.maxZoom || MAX_SUPPORTED_ZOOM_LEVEL);
+        } else {
+          this.elementInst.eachLayer(layer => {
+            if (layer.options)
+              this._clampZoomForLayer(layer.options.minZoom, layer.options.maxZoom);
+          });
+        }
+
+
+        this.elementInst.options.unclampZoomToLayers = nextOptions.unclampZoomToLayers;
       }
 
       if (!lastOptions.dragging && nextOptions.dragging) {
@@ -642,14 +703,18 @@
      * Overrides the configured min/max zoom levels if they fall outside
      * the supported bounds for a layer.
      */
-    _clampZoomForLayer(evt) {
-      if (!evt.layer || !evt.layer.options) return;
+    _clampZoomForLayer(minZoom, maxZoom) {
+      if (this.unclampZoomToLayers) return;
 
-      if (evt.layer.options.minZoom > this.options.minZoom) 
-        this.options.minZoom = evt.layer.options.minZoom;
+      if (minZoom > this.elementInst.options.minZoom) {
+        this.elementInst.setMinZoom(minZoom);
+        this._clampedMinZoom = minZoom;
+      } 
 
-      if (evt.layer.options.maxZoom < this.options.maxZoom) 
-        this.options.maxZoom = evt.layer.options.maxZoom;
+      if (maxZoom < this.elementInst.options.maxZoom) {
+        this.elementInst.setMaxZoom(maxZoom);
+        this._clampedMaxZoom = maxZoom;
+      } 
     },
 
     /**

--- a/test/px-map-root-fixture.html
+++ b/test/px-map-root-fixture.html
@@ -77,6 +77,12 @@ limitations under the License.
       </template>
     </test-fixture>
 
+    <test-fixture id="DisableZoomClamps">
+      <template>
+        <px-map style="width:100px; height:100px;" unclamp-zoom-to-layers></px-map>
+      </template>
+    </test-fixture>
+
     <!-- load test script -->
     <script src="px-map-root-tests.js"></script>
   </body>

--- a/test/px-map-root-tests.js
+++ b/test/px-map-root-tests.js
@@ -81,6 +81,120 @@ describe('Basic px-map without options', function () {
   });
 });
 
+describe('Basic px-map with zoom clamping enabled', function () {
+  var mapEl;
+
+  beforeEach(function(done) {
+    mapEl = fixture('BasicMapFixture');
+
+    flushAndRender(() => {
+      mapEl.elementInst.fire('layeradd', {
+        layer: {
+          options: {
+            minZoom: 3,
+            maxZoom: 6
+          }
+        }
+      });
+      done();
+    });
+  });
+
+  it('clamps zoom to min/max supported zoom bounds when adding layers', function() {
+    expect(mapEl.elementInst.options.minZoom).to.be.equal(3);
+    expect(mapEl.elementInst.options.maxZoom).to.be.equal(6);
+  });
+
+  it('respects zoom clamps when setting new minimum zoom level', function(done) {
+    mapEl.minZoom = 1;
+
+    flushAndRender(() => {
+      expect(mapEl.elementInst.options.minZoom).to.be.equal(3);
+      done();
+    });
+  });
+
+  it('respects zoom clamps when setting new maximum zoom level', function(done) {
+    mapEl.maxZoom = 7;
+
+    flushAndRender(() => {
+      expect(mapEl.elementInst.options.maxZoom).to.be.equal(6);
+      done();
+    });
+  });
+
+  it('allows changes to minZoom if within clamp bounds', function(done) {
+    mapEl.minZoom = 4;
+
+    flushAndRender(() => {
+      expect(mapEl.elementInst.options.minZoom).to.be.equal(4);
+      done();
+    });
+  });
+
+  it('allows changes to maxZoom if within clamp bounds', function(done) {
+    mapEl.maxZoom = 5;
+
+    flushAndRender(() => {
+      expect(mapEl.elementInst.options.maxZoom).to.be.equal(5);
+      done();
+    });
+  });
+
+  it('reverts to original zoom bounds when clamping is disabled', function(done) {
+    mapEl.unclampZoomToLayers = true;
+
+    flushAndRender(() => {
+      expect(mapEl.elementInst.options.minZoom).to.be.equal(0);
+      expect(mapEl.elementInst.options.maxZoom).to.be.equal(18);
+      done();
+    });
+  });
+})
+
+describe('Basic px-map with zoom clamping disabled', function () {
+  var mapEl;
+
+  beforeEach(function(done) {
+    mapEl = fixture('DisableZoomClamps');
+
+    flushAndRender(() => {
+      mapEl.elementInst.fire('layeradd', {
+        layer: {
+          options: {
+            minZoom: 3,
+            maxZoom: 6
+          }
+        }
+      });
+      done();
+    }, 3);
+  });
+
+  it('does not clamp zoom when new layers are added', function() {
+    expect(mapEl.elementInst.options.minZoom).to.be.equal(0);
+    expect(mapEl.elementInst.options.maxZoom).to.be.equal(18);
+  });
+
+  it('ignores zoom clamps when setting new minimum zoom level', function(done) {
+    mapEl.minZoom = 1;
+
+    flushAndRender(() => {
+      expect(mapEl.elementInst.options.minZoom).to.be.equal(1);
+      done();
+    });
+  });
+
+  it('ignores zoom clamps when setting new maximum zoom level', function(done) {
+    mapEl.maxZoom = 7;
+
+    flushAndRender(() => {
+      expect(mapEl.elementInst.options.maxZoom).to.be.equal(7);
+      done();
+    });
+  });
+})
+
 describe('Basic px-map with all zooming disabled', function () {
   var mapEl;
 
@@ -397,7 +511,7 @@ describe('px-map with fit-to-markers enabled', function() {
       expect(callWithMax).to.eql(11); // should equal map.getBoundsZoom() - 1
     });
 
-    it('corretly sets its view', function() {
+    it('correctly sets its view', function() {
       var CENTER = [1,2];
       var ZOOM = 7;
 


### PR DESCRIPTION
# Pull Request

* ## A description of the changes proposed in the pull request:

The `minZoom` and `maxZoom` options are now clamped to the min and maximum zoom levels of all children layers, to prevent users from zooming out of bounds.

For example, using the Bing layer:

**Before: (allows user to zoom out to 0, nothing visible at all)**:
<img width="612" alt="screen shot 2018-12-31 at 11 30 35 am" src="https://user-images.githubusercontent.com/4055224/50552809-833c6080-0cef-11e9-98bf-b8b397e8851e.png">

**After (zoom level 1, user prevented from zooming out further)**:
<img width="616" alt="screen shot 2018-12-31 at 2 47 23 pm" src="https://user-images.githubusercontent.com/4055224/50554224-01f2c700-0d0b-11e9-88a1-1277fca08329.png">

* ## A reference to a related issue (if applicable):

Resolves #90 
