### PR TITLE
Marker groups now accept empty feature collections

### DIFF
--- a/px-map-behavior-marker-group.es6.js
+++ b/px-map-behavior-marker-group.es6.js
@@ -344,8 +344,7 @@
         (typeof this.data !== 'object') ||
         (this.data.type !== 'FeatureCollection') ||
         (!Array.isArray(this.data.features)) ||
-        !this.data.features.length ||
-        (typeof this.data.features[0] !== 'object')
+        (this.data.features[0] && typeof this.data.features[0] !== 'object')
       );
 
       if (dataIsNotValid) {
@@ -548,7 +547,11 @@
      * @return {Set} features
      */
     _syncDataWithMarkers(newFeatures, clusterInst) {
-      if (!newFeatures.length) return;
+      if (!newFeatures.length) {
+        // If the features array is empty, clear markers and return
+        this._clearAllMarkersAndData(clusterInst);
+        return;
+      };
 
       const featuresSet = this._features = (this._features || new Set());
       const markersMap = this._markers = (this._markers || new WeakMap());

--- a/test/px-map-marker-group-tests.js
+++ b/test/px-map-marker-group-tests.js
@@ -274,4 +274,28 @@ describe('px-map-marker-group colors', function () {
       done();
     }, 3);
   });
+
+  it('clears all markers if marker-group has an empty feature array', function(done) {
+    var fx = fixture('MarkerClusterWithDefaultColors');
+
+    flushAndRender(() => {
+      var markerGroup = Polymer.dom(fx.root).querySelector('px-map').querySelector('px-map-marker-group');
+
+      // Verify marker group is currently rendering features from fixture
+      expect(markerGroup.elementInst.getLayers().length).to.not.equal(0);
+
+      // Set data to an empty feature collection and verify marker group clears existing markers
+      var emptyFeatureCol = {
+        type: "FeatureCollection",
+        features: []
+      };
+      markerGroup.data = emptyFeatureCol;
+
+      flushAndRender(() => {
+        // Validate that leaflet's rendering no layers for this marker group
+        expect(markerGroup.elementInst.getLayers().length).to.equal(0);
+        done();
+      });
+    })
+  })
 });


### PR DESCRIPTION
# Pull Request

* ## A description of the changes proposed in the pull request:

This PR allows the `px-map-marker-group` data prop to contain an empty features array.

**Before:**

Updating the px-map-marker-group data prop to empty feature array generates a console.log error and does not clear the marker group data:

![empty features bug](https://user-images.githubusercontent.com/4055224/50743156-6b715900-1268-11e9-9b51-1dda3d72c417.gif)

**After:**

![empty features fix](https://user-images.githubusercontent.com/4055224/50743233-75478c00-1269-11e9-8dc0-2270e6e2b76d.gif)


* ## A reference to a related issue (if applicable):
Resolves #87 