### PR TITLE
Google Tile Layer: Opacity

### DIFF
--- a/px-map-behavior-layer.es6.js
+++ b/px-map-behavior-layer.es6.js
@@ -31,6 +31,20 @@
    * @polymerBehavior PxMapBehavior.Layer
    */
   PxMapBehavior.LayerImpl = {
+    properties: {
+      /**
+       * Opacity of the layer. Particularly useful for reducing the intensity
+       * of colour from satellite imagery. Values between 0.0 amd 1.0
+       * This is exposed Leaflet behaviour inherited from GridLayer, see:
+       * https://leafletjs.com/reference-1.4.0.html#gridlayer.
+       */
+      opacity: {
+        type: Number,
+        value: 1.0,
+        observer: 'shouldUpdateInst'
+      }
+    },
+
     // When this element is attached to the DOM, fire an event to notify
     // a parent that it is ready
 
@@ -77,6 +91,18 @@
 
     removeInst(parent) {
       this.elementInst.remove();
+    },
+
+    superGetInstOptions: function() {
+      return {
+        opacity: this.opacity
+      };
+    },
+
+    superUpdateInst: function(lastOptions, nextOptions) {
+      if (lastOptions.opacity !== nextOptions.opacity) {
+        this.elementInst.setOpacity(nextOptions.opacity);
+      }
     },
 
     /**

--- a/px-map-behavior-layer.es6.js
+++ b/px-map-behavior-layer.es6.js
@@ -31,20 +31,6 @@
    * @polymerBehavior PxMapBehavior.Layer
    */
   PxMapBehavior.LayerImpl = {
-    properties: {
-      /**
-       * Opacity of the layer. Particularly useful for reducing the intensity
-       * of colour from satellite imagery. Values between 0.0 amd 1.0
-       * This is exposed Leaflet behaviour inherited from GridLayer, see:
-       * https://leafletjs.com/reference-1.4.0.html#gridlayer.
-       */
-      opacity: {
-        type: Number,
-        value: 1.0,
-        observer: 'shouldUpdateInst'
-      }
-    },
-
     // When this element is attached to the DOM, fire an event to notify
     // a parent that it is ready
 
@@ -91,18 +77,6 @@
 
     removeInst(parent) {
       this.elementInst.remove();
-    },
-
-    getInstOptions: function() {
-      return {
-        opacity: this.opacity
-      };
-    },
-
-    updateInst: function(lastOptions, nextOptions) {
-      if (lastOptions.opacity !== nextOptions.opacity) {
-        this.elementInst.setOpacity(nextOptions.opacity);
-      }
     },
 
     /**

--- a/px-map-behavior-layer.es6.js
+++ b/px-map-behavior-layer.es6.js
@@ -93,13 +93,13 @@
       this.elementInst.remove();
     },
 
-    superGetInstOptions: function() {
+    getInstOptions: function() {
       return {
         opacity: this.opacity
       };
     },
 
-    superUpdateInst: function(lastOptions, nextOptions) {
+    updateInst: function(lastOptions, nextOptions) {
       if (lastOptions.opacity !== nextOptions.opacity) {
         this.elementInst.setOpacity(nextOptions.opacity);
       }

--- a/px-map-behavior-tile-layer.es6.js
+++ b/px-map-behavior-tile-layer.es6.js
@@ -62,6 +62,16 @@
         type: Boolean,
         value: false,
         observer: 'shouldUpdateInst'
+      },
+
+      /**
+       * Opacity of the layer. Particularly useful for reducing the intensity
+       * of color from satellite imagery. Accepts values between 0.0 and 1.0.
+       */
+      opacity: {
+        type: Number,
+        value: 1.0,
+        observer: 'shouldUpdateInst'
       }
     },
 
@@ -77,11 +87,15 @@
       if (lastOptions.url !== nextOptions.url) {
         this.elementInst.setUrl(nextOptions.url);
       }
+      if (lastOptions.opacity !== nextOptions.opacity) {
+        this.elementInst.setOpacity(nextOptions.opacity);
+      }
     },
 
     getInstOptions() {
       return {
-        url: this.decodeUrl ? decodeURI(this.url) : this.url
+        url: this.decodeUrl ? decodeURI(this.url) : this.url,
+        opacity: this.opacity
       };
     }
   };

--- a/px-map-tile-layer-bing.html
+++ b/px-map-tile-layer-bing.html
@@ -106,6 +106,16 @@ If you do not provide an API key, the map will not load any tiles.
         type: String,
         value: 'en-US',
         observer: 'shouldUpdateInst'
+      },
+
+      /**
+       * Opacity of the layer. Particularly useful for reducing the intensity
+       * of color from satellite imagery. Accepts values between 0.0 and 1.0.
+       */
+      opacity: {
+        type: Number,
+        value: 1.0,
+        observer: 'shouldUpdateInst'
       }
     },
 
@@ -134,6 +144,9 @@ If you do not provide an API key, the map will not load any tiles.
           this.elementInst.enableAttribution();
         }
       }
+      if (lastOptions.opacity !== nextOptions.opacity) {
+        this.elementInst.setOpacity(nextOptions.opacity);
+      }
     },
 
     getInstOptions: function() {
@@ -141,7 +154,8 @@ If you do not provide an API key, the map will not load any tiles.
         bingMapsKey: this.key,
         imagerySet: this.imagery,
         culture: this.languageCode,
-        noAttribution: this.disableAttribution
+        noAttribution: this.disableAttribution,
+        opacity: this.opacity
       };
     }
   });

--- a/px-map-tile-layer-google.html
+++ b/px-map-tile-layer-google.html
@@ -119,18 +119,6 @@ If you do not provide an API key, the map will not load any tiles.
         type: Array,
         value: function() {return [];},
         observer: 'shouldUpdateInst'
-      },
-
-      /**
-       * Opacity of the layer. Particularly useful for reducing the intensity
-       * of colour from satellite imagery. Values between 0.0 amd 1.0
-       * This is exposed Leaflet behaviour inherited from GridLayer, see:
-       * https://leafletjs.com/reference-1.4.0.html#gridlayer.
-       */
-      opacity: {
-        type: Number,
-        value: 1.0,
-        observer: 'shouldUpdateInst'
       }
     },
 
@@ -158,18 +146,18 @@ If you do not provide an API key, the map will not load any tiles.
       if (lastOptions.mapStyleHash !== nextOptions.mapStyleHash) {
         this.elementInst.setMapStyle(nextOptions.mapStyle);
       }
+      this.superUpdateInst(lastOptions, nextOptions);
     },
 
     getInstOptions: function() {
-      return {
+      return Object.assign(this.superGetInstOptions(), {
         GoogleTileAPIKey: this.key,
         imagery: this.imagery,
         language: this.language,
         region: this.region,
         mapStyle: this.mapStyle,
-        mapStyleHash: JSON.stringify(this.mapStyle || []),
-        opacity: this.opacity
-      };
+        mapStyleHash: JSON.stringify(this.mapStyle || [])
+      });
     }
   });
 </script>

--- a/px-map-tile-layer-google.html
+++ b/px-map-tile-layer-google.html
@@ -119,6 +119,18 @@ If you do not provide an API key, the map will not load any tiles.
         type: Array,
         value: function() {return [];},
         observer: 'shouldUpdateInst'
+      },
+
+      /**
+       * Opacity of the layer. Particularly useful for reducing the intensity
+       * of colour from satellite imagery. Values between 0.0 amd 1.0
+       * This is exposed Leaflet behaviour inherited from GridLayer, see:
+       * https://leafletjs.com/reference-1.4.0.html#gridlayer.
+       */
+      opacity: {
+        type: Number,
+        value: 1.0,
+        observer: 'shouldUpdateInst'
       }
     },
 
@@ -146,18 +158,21 @@ If you do not provide an API key, the map will not load any tiles.
       if (lastOptions.mapStyleHash !== nextOptions.mapStyleHash) {
         this.elementInst.setMapStyle(nextOptions.mapStyle);
       }
-      PxMapBehavior.LayerImpl.updateInst.call(this, lastOptions, nextOptions);
+      if (lastOptions.opacity !== nextOptions.opacity) {
+        this.elementInst.setOpacity(nextOptions.opacity);
+      }
     },
 
     getInstOptions: function() {
-      return Object.assign(PxMapBehavior.LayerImpl.getInstOptions.call(this), {
+      return {
         GoogleTileAPIKey: this.key,
         imagery: this.imagery,
         language: this.language,
         region: this.region,
         mapStyle: this.mapStyle,
-        mapStyleHash: JSON.stringify(this.mapStyle || [])
-      });
+        mapStyleHash: JSON.stringify(this.mapStyle || []),
+        opacity: this.opacity
+      };
     }
   });
 </script>

--- a/px-map-tile-layer-google.html
+++ b/px-map-tile-layer-google.html
@@ -119,6 +119,18 @@ If you do not provide an API key, the map will not load any tiles.
         type: Array,
         value: function() {return [];},
         observer: 'shouldUpdateInst'
+      },
+
+      /**
+       * Opacity of the layer. Particularly useful for reducing the intensity
+       * of colour from satellite imagery. Values between 0.0 amd 1.0
+       * This is exposed Leaflet behaviour inherited from GridLayer, see:
+       * https://leafletjs.com/reference-1.4.0.html#gridlayer.
+       */
+      opacity: {
+        type: Number,
+        value: 1.0,
+        observer: 'shouldUpdateInst'
       }
     },
 
@@ -155,7 +167,8 @@ If you do not provide an API key, the map will not load any tiles.
         language: this.language,
         region: this.region,
         mapStyle: this.mapStyle,
-        mapStyleHash: JSON.stringify(this.mapStyle || [])
+        mapStyleHash: JSON.stringify(this.mapStyle || []),
+        opacity: this.opacity
       };
     }
   });

--- a/px-map-tile-layer-google.html
+++ b/px-map-tile-layer-google.html
@@ -146,11 +146,11 @@ If you do not provide an API key, the map will not load any tiles.
       if (lastOptions.mapStyleHash !== nextOptions.mapStyleHash) {
         this.elementInst.setMapStyle(nextOptions.mapStyle);
       }
-      this.superUpdateInst(lastOptions, nextOptions);
+      PxMapBehavior.LayerImpl.updateInst.call(this, lastOptions, nextOptions);
     },
 
     getInstOptions: function() {
-      return Object.assign(this.superGetInstOptions(), {
+      return Object.assign(PxMapBehavior.LayerImpl.getInstOptions.call(this), {
         GoogleTileAPIKey: this.key,
         imagery: this.imagery,
         language: this.language,

--- a/px-map-tile-layer-google.html
+++ b/px-map-tile-layer-google.html
@@ -123,7 +123,7 @@ If you do not provide an API key, the map will not load any tiles.
 
       /**
        * Opacity of the layer. Particularly useful for reducing the intensity
-       * of colour from satellite imagery. Values between 0.0 amd 1.0
+       * of color from satellite imagery. Values between 0.0 and 1.0
        * This is exposed Leaflet behaviour inherited from GridLayer, see:
        * https://leafletjs.com/reference-1.4.0.html#gridlayer.
        */

--- a/px-map-tile-layer-google.html
+++ b/px-map-tile-layer-google.html
@@ -123,9 +123,7 @@ If you do not provide an API key, the map will not load any tiles.
 
       /**
        * Opacity of the layer. Particularly useful for reducing the intensity
-       * of color from satellite imagery. Values between 0.0 and 1.0
-       * This is exposed Leaflet behaviour inherited from GridLayer, see:
-       * https://leafletjs.com/reference-1.4.0.html#gridlayer.
+       * of color from satellite imagery. Accepts values between 0.0 and 1.0.
        */
       opacity: {
         type: Number,

--- a/px-map-tile-layer-wms.html
+++ b/px-map-tile-layer-wms.html
@@ -133,6 +133,16 @@ instructions on how to configure it to request WMS tiles [on the Leaflet website
         type: String,
         value: '',
         observer: 'shouldUpdateInst'
+      },
+
+      /**
+       * Opacity of the layer. Particularly useful for reducing the intensity
+       * of color from satellite imagery. Accepts values between 0.0 and 1.0.
+       */
+      opacity: {
+        type: Number,
+        value: 1.0,
+        observer: 'shouldUpdateInst'
       }
     },
 
@@ -150,6 +160,9 @@ instructions on how to configure it to request WMS tiles [on the Leaflet website
       }
       if (lastOptions.wmsOptionsHash !== nextOptions.wmsOptionsHash) {
         this.elementInst.setParams(nextOptions.wmsOptions);
+      }
+      if (lastOptions.opacity !== nextOptions.opacity) {
+        this.elementInst.setOpacity(nextOptions.opacity);
       }
     },
 
@@ -174,7 +187,8 @@ instructions on how to configure it to request WMS tiles [on the Leaflet website
       return {
         url: this.url,
         wmsOptions: wmsOptions,
-        wmsOptionsHash: JSON.stringify(wmsOptions)
+        wmsOptionsHash: JSON.stringify(wmsOptions),
+        opacity: this.opacity
       };
     }
   });


### PR DESCRIPTION
# Pull Request

* ## A description of the changes proposed in the pull request:
The px-map-tile-layer-google exposes a restricted set of options. This change adds 'opacity' (a standard Leaflet option) to the list. The driver for this is to make the satellite imagery more usable. The imagery tends to be dark or have heavy colour saturation which makes feature styles difficult to see. Reducing the opacity mutes the satellite map to improve clarity.

* ## A reference to a related issue (if applicable):
N/A

* ## @mentions of the person or team responsible for reviewing proposed changes:
@evanjd 

* ## working tests:
#### wct tests all pass. There is no additional test for this change
